### PR TITLE
Fix for issue #15

### DIFF
--- a/src/main/clojure/clj_logging_config/jul.clj
+++ b/src/main/clojure/clj_logging_config/jul.clj
@@ -166,7 +166,7 @@
 
 (defmacro set-logger-level!
   ([level]
-     `(_set-logger-level! (name (ns-name ~*ns*)) ~level))
+     `(_set-logger-level! (name (ns-name *ns*)) ~level))
   ([logger level]
      `(do
         (_set-logger-level! ~logger ~level))))
@@ -178,7 +178,7 @@
 
 (defmacro set-logger-use-parent-handlers!
   ([value]
-     `(_set-logger-use-parent-handlers! (name (ns-name ~*ns*)) ~value))
+     `(_set-logger-use-parent-handlers! (name (ns-name *ns*)) ~value))
   ([logger value]
      `(do
         (_set-logger-use-parent-handlers! ~logger ~value))))

--- a/src/main/clojure/clj_logging_config/log4j.clj
+++ b/src/main/clojure/clj_logging_config/log4j.clj
@@ -254,7 +254,7 @@ list with one entry."
 
 (defmacro set-logger! [& [logger & args :as allargs]]
   (cond (or (empty? allargs) (keyword? logger))
-        `(set-loggers! (name (ns-name ~*ns*)) ~(apply hash-map allargs))
+        `(set-loggers! (name (ns-name *ns*)) ~(apply hash-map allargs))
         :otherwise
         `(set-loggers! ~logger ~(apply hash-map args))))
 
@@ -267,7 +267,7 @@ list with one entry."
 
 (defmacro set-logger-level!
   ([level]
-     `(set-logger-level! (name (ns-name ~*ns*)) ~level))
+     `(set-logger-level! (name (ns-name *ns*)) ~level))
   ([logger level]
      `(do
         (_set-logger-level! ~logger ~level))))
@@ -281,7 +281,7 @@ list with one entry."
 
 (defmacro set-logger-additivity!
   ([value]
-     `(set-logger-additivity! (name (ns-name ~*ns*)) ~value))
+     `(set-logger-additivity! (name (ns-name *ns*)) ~value))
   ([logger value]
      `(do
         (_set-logger-additivity! ~logger ~value))))


### PR DESCRIPTION
Unquoting _ns_ in a macro causes it to resolve to nil in runtime when the project is AOT compiled, thus causing namespace lookups to fail

Please see [issue #15](https://github.com/malcolmsparks/clj-logging-config/issues/15) - it includes the rationale behind this fix, as well as a sample application that replicates the issue.
