### PR TITLE
Another reflection warning

### DIFF
--- a/src/main/clojure/clj_logging_config/log4j.clj
+++ b/src/main/clojure/clj_logging_config/log4j.clj
@@ -181,7 +181,7 @@ list with one entry."
         ;; Try to infer whether an appender is required for this logger
         ;; If the out parameter is given, or a layout is given, then an appender
         ;; needs to be added.
-        ^Appender appender
+        ^AppenderSkeleton appender
         (cond
          (instance? Appender out) out
          (fn? out) (create-appender-adapter out name)


### PR DESCRIPTION
setThreshold method is on AppenderSkeleton, not the Appender interface:

> Reflection warning, clj_logging_config/log4j.clj:229:20 - call to method setThreshold on org.apache.log4j.Appender can't be resolved (no such method).
